### PR TITLE
Remove resetMocks() with AbstractJerseyJUnit

### DIFF
--- a/scripts/testng-junit/src/testng2junit.py
+++ b/scripts/testng-junit/src/testng2junit.py
@@ -137,6 +137,8 @@ def migrate_testng_annotations(content):
 
   # Migrate AbstractJerseyTestNG to AbstractJerseyJUnit
   content_new = re.sub('AbstractJerseyTestNG', 'AbstractJerseyJUnit', content_new)
+  if 'AbstractJerseyJUnit' in content_new:
+      content_new = re.sub('\s+(this.)?resetMocks\(\);', '', content_new)
 
   # Ensure test methods are public
   content_new = re.sub('@Test\n  void', '@Test\n  public void', content_new)


### PR DESCRIPTION
`resetMocks()` is no longer needed after migration to AbstractJerseyJUnit because the mocks are reset in the `@Before` method for every test.

@calcwu 