### PR TITLE
Ensure that migration of assertNotNull statements is single-line

### DIFF
--- a/scripts/testng-junit/src/testng2junit5.py
+++ b/scripts/testng-junit/src/testng2junit5.py
@@ -290,7 +290,7 @@ def migrate_asserts(content):
   # message, obj1, obj2.
 
   #replace assertNotNull
-  pattern = r'assertNotNull\(([^,]+),\s*"([^"]+)"\);'
+  pattern = r'assertNotNull\(([^;,]+),\s*\"([^\"]+)\"\);'
 
   # Use re.sub() to replace the pattern with the desired format
   content_new = re.sub(pattern, r'assertNotNull("\2", \1);', content)

--- a/scripts/testng-junit/src/testng2junit5.py
+++ b/scripts/testng-junit/src/testng2junit5.py
@@ -290,7 +290,7 @@ def migrate_asserts(content):
   # message, obj1, obj2.
 
   #replace assertNotNull
-  pattern = r'assertNotNull\(([^;,]+),\s*\"([^\"]+)\"\);'
+  pattern = r'assertNotNull\(([^;,]+),\s*"([^"]+)"\);'
 
   # Use re.sub() to replace the pattern with the desired format
   content_new = re.sub(pattern, r'assertNotNull("\2", \1);', content)

--- a/scripts/testng-junit/src/tests/test_migrate_assert.py
+++ b/scripts/testng-junit/src/tests/test_migrate_assert.py
@@ -1,14 +1,19 @@
 from setup import testng2junit5
 
-content = """
 
-        GffValidation gffValidation = result.getGffValidation();
-        assertNotNull(gffValidation, "gffValidation");
-        List<GffAccountValidation> accountValidations = gffValidation.getAccounts().getItem();
-
-"""
-
-
-def test_migrate_assert():
+def test_migrate_assert_reverse_arguments():
+    content = """
+            GffValidation gffValidation = result.getGffValidation();
+            assertNotNull(gffValidation, "gffValidation");
+            List<GffAccountValidation> accountValidations = gffValidation.getAccounts().getItem();
+    """
     content_new = testng2junit5.migrate_asserts(content)
     assert 'assertNotNull("gffValidation", gffValidation);' in content_new
+
+
+def test_migrate_assert_doesnt_span_logical_lines():
+    original = """
+assertNotNull("a");
+assertEquals("b", "c");
+"""
+    assert testng2junit5.migrate_asserts(original) == original


### PR DESCRIPTION
Previously, the first capturing group of the regular expression migrating these statements was not confined to non-semicolon characters, so it was able to span multiple logical lines, incorrectly.

This patch adds a non-semicolon constraint, preventing this behavior.